### PR TITLE
Events Bug Fixes

### DIFF
--- a/library/sass/_global.scss
+++ b/library/sass/_global.scss
@@ -310,6 +310,9 @@ nav.pagination {
 	border-bottom: $border;
 	padding-bottom: $padding;
 	@extend .h3;
+	.prev-link {
+		float: left;
+	}
 	.next-link {
 		float: right;
 	}

--- a/library/sass/_grid.scss
+++ b/library/sass/_grid.scss
@@ -50,7 +50,7 @@ footer, div.category > article + article {
   margin-top: $padding/2;
 }
 
-main > header, .tribe-events-title-bar {
+main > header, .calendar-header {
 	margin-top: $padding/2;
 	margin-bottom: $padding;
 }
@@ -101,7 +101,7 @@ body.home {
 		min-height: 25rem;
 	}
 
-	main > header, .tribe-events-title-bar {
+	main > header, .calendar-header {
 		margin-top: $padding*1.5;
 		margin-bottom: $padding*1.5;
 	}

--- a/library/sass/_grid.scss
+++ b/library/sass/_grid.scss
@@ -50,7 +50,7 @@ footer, div.category > article + article {
   margin-top: $padding/2;
 }
 
-main > header, #tribe-events-content > header {
+main > header, .tribe-events-title-bar {
 	margin-top: $padding/2;
 	margin-bottom: $padding;
 }
@@ -101,7 +101,7 @@ body.home {
 		min-height: 25rem;
 	}
 
-	main > header, #tribe-events-content > header {
+	main > header, .tribe-events-title-bar {
 		margin-top: $padding*1.5;
 		margin-bottom: $padding*1.5;
 	}

--- a/library/sass/_grid.scss
+++ b/library/sass/_grid.scss
@@ -15,7 +15,7 @@ hr  {
 	width: 100%;
 }
 
-#header > div, .announcement > p, .articles > div, footer > div, .subfooter > div, .single main > article, section.tags {
+#header > div, .announcement > p, .articles > div, footer > div, .subfooter > div, .single main > article, .single-event-article, section.tags {
 	@include grid-row;
 }
 
@@ -232,7 +232,7 @@ body.home {
 		main {
 			@include grid-row;
 		}
-		main > article, section.tags, section.comments { // everything except section.related-posts
+		main > article, .single-event-article, section.tags, section.comments { // everything except section.related-posts
 			@include grid-column(10);
 			@include grid-col-pos(center);
 		}

--- a/library/sass/_site-specific.scss
+++ b/library/sass/_site-specific.scss
@@ -200,6 +200,10 @@ body.home .recurringinfo, body.archive .recurringinfo {
 	display: none; // hide recurring-event info
 }
 
+.tribe-events-page-title {
+	text-align: left;
+}
+
 .tribe-events-button {
 	@extend .button;
 }

--- a/partials/pagination.php
+++ b/partials/pagination.php
@@ -4,22 +4,10 @@ used on archive, events archive, and search-results pages
 -->
 
 <nav class="pagination">
-    <span class="prev-link">
-	<?php 
-		if ( tribe_is_event_query() ) { // if it's an event page
-			previous_posts_link(__('&#8592; Earlier', 'bhass'));
-		} else {
-    		next_posts_link(__('&#8592; Older', 'bhass'));
-		}
-	?>
-    </span>
-    <span class="next-link">
-		<?php 
-			if ( tribe_is_event_query() ) { // if it's an event page
-				next_posts_link(__('Later &#8594;', 'bhass'));
-			} else {
-	    		previous_posts_link(__('Newer &#8594;', 'bhass'));
-			}
-		?>
-    </span>
-</nav> 
+	<span class="prev-link">
+		<?php next_posts_link(__('&#8592; Older', 'bhass')); ?>
+	</span>
+	<span class="next-link">
+		<?php previous_posts_link(__('Newer &#8594;', 'bhass')); ?>
+	</span>
+</nav>

--- a/tribe-events/list.php
+++ b/tribe-events/list.php
@@ -21,11 +21,11 @@ do_action( 'tribe_events_before_template' );
 <!-- Title Bar -->
 <?php tribe_get_template_part( 'list/title-bar' ); ?>
 
-	<!-- Tribe Bar -->
-<?php tribe_get_template_part( 'modules/bar' ); ?>
-
-	<!-- Main Events Content -->
+<!-- Main Events Content -->
 <?php tribe_get_template_part( 'list/content' ); ?>
+
+<!-- Sidebar -->
+<?php get_sidebar('events'); ?>
 
 	<div class="tribe-clear"></div>
 

--- a/tribe-events/list.php
+++ b/tribe-events/list.php
@@ -1,49 +1,33 @@
 <?php
 /**
  * List View Template
+ * The wrapper template for a list of events. This includes the Past Events and Upcoming Events views
+ * as well as those same views filtered to a specific category.
+ *
+ * Override this template in your own theme by creating a file at [your-theme]/tribe-events/list.php
+ *
+ * @package TribeEventsCalendar
+ * @version 4.6.19
  *
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	die( '-1' );
+}
+
+do_action( 'tribe_events_before_template' );
 ?>
 
-<div id="tribe-events-content" class="tribe-events-list">
-  
-  <header class="calendar-header">
-    <h1><?php echo tribe_get_events_title(); ?></h1>
-    <?php bhass_featured_event_categories(); ?>
-    <?php tribe_get_template_part( 'modules/bar' ); ?>
-  </header>
+<!-- Title Bar -->
+<?php tribe_get_template_part( 'list/title-bar' ); ?>
 
-  <div id="tribe-events-content" class="right">
+	<!-- Tribe Bar -->
+<?php tribe_get_template_part( 'modules/bar' ); ?>
 
-      <?php
-      if ( ! defined( 'ABSPATH' ) ) {
-        die( '-1' );
-      }
+	<!-- Main Events Content -->
+<?php tribe_get_template_part( 'list/content' ); ?>
 
-      do_action( 'tribe_events_before_template' );
-      do_action( 'tribe_events_list_before_the_content' );
-      ?>
+	<div class="tribe-clear"></div>
 
-      <!-- Events Loop -->
-      <?php if ( have_posts() ) : ?>
-        <?php do_action( 'tribe_events_before_loop' ); ?>
-        <?php tribe_get_template_part( 'list/loop' ) ?>
-        <?php do_action( 'tribe_events_after_loop' ); ?>
-      <?php 
-        endif;
-        get_template_part('partials/pagination');
-      ?>
-
-      </div>
-
-      <!-- #tribe-events-footer -->
-      <?php do_action( 'tribe_events_after_footer' ) ?>
-
-  </div>
-
-  <?php get_sidebar('events'); ?>
-
-</div>
 <?php
 do_action( 'tribe_events_after_template' );

--- a/tribe-events/list/content.php
+++ b/tribe-events/list/content.php
@@ -28,6 +28,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<!-- Notices -->
 	<?php tribe_the_notices() ?>
 
+	<!-- List Header -->
+	<!-- apparently necessary for browser title to function correctly while using pagination -->
+	<div id="tribe-events-header" <?php tribe_events_the_header_attributes() ?>>
+
+		<!-- Header Navigation -->
+		<?php do_action( 'tribe_events_before_header_nav' ); ?>
+		<?php do_action( 'tribe_events_after_header_nav' ); ?>
+
+	</div>
+	<!-- #tribe-events-header -->
+
 	<!-- Events Loop -->
 	<?php if ( have_posts() ) : ?>
 		<?php do_action( 'tribe_events_before_loop' ); ?>

--- a/tribe-events/list/content.php
+++ b/tribe-events/list/content.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( '-1' );
 } ?>
 
-<div id="tribe-events-content" class="left">
+<div id="tribe-events-content" class="right">
 
 
 	<?php

--- a/tribe-events/list/content.php
+++ b/tribe-events/list/content.php
@@ -28,20 +28,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<!-- Notices -->
 	<?php tribe_the_notices() ?>
 
-	<!-- List Header -->
-	<?php do_action( 'tribe_events_before_header' ); ?>
-	<div id="tribe-events-header" <?php tribe_events_the_header_attributes() ?>>
-
-		<!-- Header Navigation -->
-		<?php do_action( 'tribe_events_before_header_nav' ); ?>
-		<?php tribe_get_template_part( 'list/nav', 'header' ); ?>
-		<?php do_action( 'tribe_events_after_header_nav' ); ?>
-
-	</div>
-	<!-- #tribe-events-header -->
-	<?php do_action( 'tribe_events_after_header' ); ?>
-
-
 	<!-- Events Loop -->
 	<?php if ( have_posts() ) : ?>
 		<?php do_action( 'tribe_events_before_loop' ); ?>

--- a/tribe-events/list/loop.php
+++ b/tribe-events/list/loop.php
@@ -5,6 +5,7 @@
  *
  * Override this template in your own theme by creating a file at [your-theme]/tribe-events/list/loop.php
  *
+ * @version 4.4
  * @package TribeEventsCalendar
  *
  */
@@ -19,16 +20,38 @@ global $more;
 $more = false;
 ?>
 
-<?php while ( have_posts() ) : the_post();
-	do_action( 'tribe_events_inside_before_loop' );
+<div class="tribe-events-loop">
 
-	if ( tribe_event_in_category('hassle-shows') ) {
-		$hassle_show = true;
-	} else {
-		$hassle_show = false;
-	}
+	<?php while ( have_posts() ) : the_post(); ?>
+		<?php do_action( 'tribe_events_inside_before_loop' ); ?>
 
-	include(locate_template('partials/event.php'));
+		<!-- Month / Year Headers -->
+		<?php tribe_events_list_the_date_headers(); ?>
 
-	do_action( 'tribe_events_inside_after_loop' );
-endwhile; ?>
+		<!-- Event  -->
+		<?php
+		$post_parent = '';
+		if ( $post->post_parent ) {
+			$post_parent = ' data-parent-post-id="' . absint( $post->post_parent ) . '"';
+		}
+		?>
+		<div id="post-<?php the_ID() ?>" class="<?php tribe_events_event_classes() ?>" <?php echo $post_parent; ?>>
+			<?php
+			$event_type = tribe( 'tec.featured_events' )->is_featured( $post->ID ) ? 'featured' : 'event';
+
+			/**
+			 * Filters the event type used when selecting a template to render
+			 *
+			 * @param $event_type
+			 */
+			$event_type = apply_filters( 'tribe_events_list_view_event_type', $event_type );
+
+			tribe_get_template_part( 'list/single', $event_type );
+			?>
+		</div>
+
+
+		<?php do_action( 'tribe_events_inside_after_loop' ); ?>
+	<?php endwhile; ?>
+
+</div><!-- .tribe-events-loop -->

--- a/tribe-events/list/loop.php
+++ b/tribe-events/list/loop.php
@@ -25,9 +25,6 @@ $more = false;
 	<?php while ( have_posts() ) : the_post(); ?>
 		<?php do_action( 'tribe_events_inside_before_loop' ); ?>
 
-		<!-- Month / Year Headers -->
-		<?php tribe_events_list_the_date_headers(); ?>
-
 		<!-- Event  -->
 		<?php
 

--- a/tribe-events/list/loop.php
+++ b/tribe-events/list/loop.php
@@ -30,25 +30,16 @@ $more = false;
 
 		<!-- Event  -->
 		<?php
-		$post_parent = '';
-		if ( $post->post_parent ) {
-			$post_parent = ' data-parent-post-id="' . absint( $post->post_parent ) . '"';
+
+		if ( tribe_event_in_category('hassle-shows') ) {
+			$hassle_show = true;
+		} else {
+			$hassle_show = false;
 		}
+
+		include(locate_template('partials/event.php'));
+
 		?>
-		<div id="post-<?php the_ID() ?>" class="<?php tribe_events_event_classes() ?>" <?php echo $post_parent; ?>>
-			<?php
-			$event_type = tribe( 'tec.featured_events' )->is_featured( $post->ID ) ? 'featured' : 'event';
-
-			/**
-			 * Filters the event type used when selecting a template to render
-			 *
-			 * @param $event_type
-			 */
-			$event_type = apply_filters( 'tribe_events_list_view_event_type', $event_type );
-
-			tribe_get_template_part( 'list/single', $event_type );
-			?>
-		</div>
 
 
 		<?php do_action( 'tribe_events_inside_after_loop' ); ?>

--- a/tribe-events/list/nav.php
+++ b/tribe-events/list/nav.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * List View Nav Template
+ * This file loads the list view navigation.
+ *
+ * Override this template in your own theme by creating a file at [your-theme]/tribe-events/list/nav.php
+ *
+ * @package TribeEventsCalendar
+ * @version 4.6.19
+ *
+ */
+if ( ! $wp_query = tribe_get_global_query_object() ) {
+	return;
+}
+
+$events_label_plural = tribe_get_event_label_plural();
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( '-1' );
+} ?>
+
+<nav class="pagination tribe-events-nav-pagination" aria-label="<?php echo esc_html( sprintf( esc_html__( '%s List Navigation', 'the-events-calendar' ), $events_label_plural ) ); ?>">
+	<ul class="tribe-events-sub-nav">
+		<!-- Left Navigation -->
+
+		<?php if ( tribe_has_previous_event() ) : ?>
+			<li class="prev-link <?php echo esc_attr( tribe_left_navigation_classes() ); ?>">
+				<a href="<?php echo esc_url( tribe_get_listview_prev_link() ); ?>" rel="prev"><span>&#8592;</span> <?php echo esc_html( sprintf( __( 'Earlier', 'the-events-calendar' ), $events_label_plural ) ); ?></a>
+
+			</li><!-- .tribe-events-nav-left -->
+		<?php endif; ?>
+
+		<!-- Right Navigation -->
+		<?php if ( tribe_has_next_event() ) : ?>
+			<li class="next-link <?php echo esc_attr( tribe_right_navigation_classes() ); ?>">
+				<a href="<?php echo esc_url( tribe_get_listview_next_link() ); ?>" rel="next"><?php echo esc_html( sprintf( __( 'Later', 'the-events-calendar' ), $events_label_plural ) ); ?> <span>&#8594;</span></a>
+			</li><!-- .tribe-events-nav-right -->
+		<?php endif; ?>
+	</ul>
+</nav>

--- a/tribe-events/list/title-bar.php
+++ b/tribe-events/list/title-bar.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * List View Title Template
+ * The title template for the list view of events.
+ *
+ * Override this template in your own theme by creating a file at [your-theme]/tribe-events/list/title-bar.php
+ *
+ * @package TribeEventsCalendar
+ * @version 4.6.19
+ * @since   4.6.19
+ *
+ */
+?>
+
+<header class="calendar-header tribe-events-title-bar">
+
+	<?php do_action( 'tribe_events_before_the_title' ); ?>
+	<h1 class="tribe-events-page-title"><?php echo tribe_get_events_title() ?></h1>
+	<?php bhass_featured_event_categories(); ?>
+	<?php do_action( 'tribe_events_after_the_title' ); ?>
+
+	<?php tribe_get_template_part( 'modules/bar' ); ?>
+</header>

--- a/tribe-events/single-event.php
+++ b/tribe-events/single-event.php
@@ -41,7 +41,7 @@ $event_id = get_the_ID();
       </p>
     </header>
 
-    <article>
+    <article class="single-event-article">
 
     	<?php echo tribe_event_featured_image( $event_id, 'full', false ); ?>
 


### PR DESCRIPTION
Fix issues, most likely due to incompatibilities with the Events Calendar plugin update:

- fix jacked-up looking calendar-switcher
- fix pagination on category pages
- fix large images breaking out of layout on single Event pages


To Do:
- Keep calendar-switcher from disappearing when clicked